### PR TITLE
Fix workspaceName type and userid description typo in User Management API

### DIFF
--- a/static/swagger-user.json
+++ b/static/swagger-user.json
@@ -773,7 +773,7 @@
         },
        "userid": {
           "type": "string",
-          "description": "Marketo Identity users should an email address. Adobe Identity users should use the generated GUID."		  
+          "description": "Marketo Identity users should use an email address. Adobe Identity users should use the generated GUID."		  
         },		
        "reason": {
           "type": "string",
@@ -875,7 +875,7 @@
         },
         "userid": {
           "type": "string",
-          "description": "Marketo Identity users should an email address. Adobe Identity users should use the generated GUID." 		  
+          "description": "Marketo Identity users should use an email address. Adobe Identity users should use the generated GUID." 		  
         }
       },
       "title": "ResponseOfUser"
@@ -921,7 +921,7 @@
         },
         "userid": {
           "type": "string",
-          "description": "Marketo Identity users should an email address. Adobe Identity users should use the generated GUID." 		  
+          "description": "Marketo Identity users should use an email address. Adobe Identity users should use the generated GUID." 		  
         },		
         "subscriptionId": {
           "type": "string",
@@ -993,7 +993,7 @@
         },
         "userid": {
           "type": "string",
-          "description": "Marketo Identity users should an email address. Adobe Identity users should use the generated GUID." 		  
+          "description": "Marketo Identity users should use an email address. Adobe Identity users should use the generated GUID." 		  
         }
       },
       "title": "ResponseOfAllUsers"
@@ -1020,10 +1020,9 @@
           "format": "int32"
         },
         "workspaceName": {
-          "type": "integer",
-          "description": "User workspace name",		  		  		  		  		  
-          "format": "int32"
-        }		
+          "type": "string",
+          "description": "User workspace name"
+        }
       },
       "title": "UserRoleWorkspace"
     },


### PR DESCRIPTION
## Description

Two fixes in `swagger-user.json`:

### 1. `workspaceName` typed as `integer` instead of `string`

`UserRoleWorkspace.workspaceName` (line 1022) is defined as `type: "integer", format: "int32"`, but workspace names are strings (e.g. "NAM", "EMEA", "Global"). The sibling field `workspaceId` correctly uses `integer` — `workspaceName` should be `string`.

This causes client SDK codegen tools (e.g. OpenAPI Generator, Swagger Codegen) to produce incorrect types for the workspace name field.

### 2. Missing verb in `userid` description

The `userid` field description reads:

> "Marketo Identity users should an email address."

Missing the verb "use." Fixed in all 4 occurrences (`InviteUserRequest`, `ResponseOfUser`, `User`, `ResponseOfAllUsers`).

## Motivation

Found while building a Marketo REST API integration and running the spec through OpenAPI codegen. The integer type for `workspaceName` produced a broken client that couldn't deserialize workspace name strings from the API response.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)