### PR TITLE
Fix incorrect required fields in Bulk Export filter schemas

### DIFF
--- a/static/swagger-mapi.json
+++ b/static/swagger-mapi.json
@@ -11227,14 +11227,6 @@
     },
     "ExportLeadFilter": {
       "type": "object",
-      "required": [
-        "createdAt",
-        "smartListId",
-        "smartListName",
-        "staticListId",
-        "staticListName",
-        "updatedAt"
-      ],
       "properties": {
         "createdAt": {
           "description": "Date range to filter new leads on",
@@ -11266,13 +11258,6 @@
     },
     "ExportCustomObjectFilter": {
       "type": "object",
-      "required": [
-        "updatedAt",	  
-        "smartListId",
-        "smartListName",
-        "staticListId",
-        "staticListName"
-      ],
       "properties": {
         "updatedAt": {
           "description": "Date range to filter updated custom objects on",
@@ -11300,10 +11285,6 @@
     },	
     "ExportProgramMemberFilter": {
       "type": "object",
-      "required": [
-        "programId",
-        "programIds"		
-      ],
       "properties": {	  
         "programId": {
           "type": "integer",


### PR DESCRIPTION
## Description

Three Bulk Export filter schemas in `swagger-mapi.json` incorrectly mark all filter fields as `required`:

### `ExportLeadFilter`
Lists `createdAt`, `updatedAt`, `staticListId`, `staticListName`, `smartListId`, and `smartListName` as **all required**. In practice, these are mutually exclusive options — you provide exactly **one** filter type per export job. The [Bulk Lead Extract documentation](https://experienceleague.adobe.com/en/docs/marketo-developer/marketo/rest/bulk-extract/bulk-lead-extract) confirms this: each filter is an independent selection criterion.

### `ExportCustomObjectFilter`
Same issue — lists `updatedAt`, `smartListId`, `smartListName`, `staticListId`, `staticListName` as all required.

### `ExportProgramMemberFilter`
Lists both `programId` and `programIds` as required, even though the descriptions explicitly state they "Cannot be used in combination with" each other.

**`ExportActivityFilter` is left unchanged** — its `required: ["createdAt"]` is correct, as `createdAt` is genuinely always required for activity exports.

## Impact

Client SDK codegen tools (OpenAPI Generator, Swagger Codegen) generate validation that demands all filter fields simultaneously, producing requests the API rejects. Developers using generated clients must work around or patch the spec manually.

## Motivation

Discovered while building a Bulk Export integration for lead data warehousing. The generated TypeScript client required all 6 filter fields, failing schema validation before even reaching the API.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)