### PR TITLE
Fix incomplete nurtureCadence enum values

### DIFF
--- a/static/swagger-mapi.json
+++ b/static/swagger-mapi.json
@@ -11326,8 +11326,8 @@
           "type": "string",
           "description": "Filter program membership records for a given nurture cadence",
           "enum": [
-            "paus",
-            "norm"
+            "paused",
+            "normal"
           ]
         },
         "statusNames": {


### PR DESCRIPTION
## Description

In `swagger-mapi.json`, the `ExportProgramMemberFilter.nurtureCadence` enum contains incomplete values:

- `paus` should be `paused`
- `norm` should be `normal`

These match the Marketo API's actual accepted values for filtering program members by nurture cadence in Bulk Export jobs.

## Impact

Client SDK codegen tools generate enum types with the incomplete values, causing requests with valid cadence filters to be rejected by client-side validation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)