### PR TITLE
Fix typos and misspellings in Lead Database API spec

### DIFF
--- a/static/swagger-mapi.json
+++ b/static/swagger-mapi.json
@@ -2245,7 +2245,7 @@
           "Campaigns"
         ],
         "summary": "Get Campaigns",
-        "description": "Returns a list of campaign records. Required Permissions: Read-Only Campaigns, Read-Write Campaigns<br><br><b>Note: This endpoint has been superceded.</b>  Use <a href=\"https://developer.adobe.com/marketo-apis/api/asset/#operation/getAllSmartCampaignsGET\">Get Smart Campaigns</a> endpoint instead.",
+        "description": "Returns a list of campaign records. Required Permissions: Read-Only Campaigns, Read-Write Campaigns<br><br><b>Note: This endpoint has been superseded.</b>  Use <a href=\"https://developer.adobe.com/marketo-apis/api/asset/#operation/getAllSmartCampaignsGET\">Get Smart Campaigns</a> endpoint instead.",
         "operationId": "getCampaignsUsingGET",
         "consumes": [
           "application/json"
@@ -2338,7 +2338,7 @@
           "Campaigns"
         ],
         "summary": "Get Campaign By Id",
-        "description": "Returns the record of a campaign by its id. Required Permissions: Read-Only Campaigns, Read-Write Campaigns<br><br><b>Note: This endpoint has been superceded.</b>  Use <a href=\"https://developer.adobe.com/marketo-apis/api/asset/#operation/getSmartCampaignByIdUsingGET\">Get Smart Campaign by Id</a> endpoint instead.",
+        "description": "Returns the record of a campaign by its id. Required Permissions: Read-Only Campaigns, Read-Write Campaigns<br><br><b>Note: This endpoint has been superseded.</b>  Use <a href=\"https://developer.adobe.com/marketo-apis/api/asset/#operation/getSmartCampaignByIdUsingGET\">Get Smart Campaign by Id</a> endpoint instead.",
         "operationId": "getCampaignByIdUsingGET",
         "consumes": [
           "application/json"
@@ -3493,7 +3493,7 @@
           "Leads"
         ],
         "summary": "Describe Lead",
-        "description": "Returns metadata about lead objects in the target instance, including a list of all fields available for interaction via the APIs. Required Permissions: Read-Only Lead, Read-Write Lead<br><br><b>Note: This endpoint has been superceded.</b>  Use <a href=\"https://developer.adobe.com/marketo-apis/api/mapi/#operation/describeUsingGET_6\">Describe Lead2</a> endpoint instead.",
+        "description": "Returns metadata about lead objects in the target instance, including a list of all fields available for interaction via the APIs. Required Permissions: Read-Only Lead, Read-Write Lead<br><br><b>Note: This endpoint has been superseded.</b>  Use <a href=\"https://developer.adobe.com/marketo-apis/api/mapi/#operation/describeUsingGET_6\">Describe Lead2</a> endpoint instead.",
         "operationId": "describeUsingGET_2",
         "consumes": [
           "application/json"
@@ -4063,7 +4063,7 @@
           "Leads"
         ],
         "summary": "Describe Program Member",
-        "description": "Returns metadata about program member objects in the target instance, including a list of all fields available for interaction via the APIs. Required Permissions: Read-Only Lead, Read-Write Lead<br><br><b>Note: This endpoint has been superceded.</b>  Use <a href=\"https://developer.adobe.com/marketo-apis/api/mapi/#operation/describeProgramMemberUsingGET2\">Describe Program Member</a> endpoint instead.",
+        "description": "Returns metadata about program member objects in the target instance, including a list of all fields available for interaction via the APIs. Required Permissions: Read-Only Lead, Read-Write Lead<br><br><b>Note: This endpoint has been superseded.</b>  Use <a href=\"https://developer.adobe.com/marketo-apis/api/mapi/#operation/describeProgramMemberUsingGET2\">Describe Program Member</a> endpoint instead.",
         "operationId": "describeProgramMemberUsingGET",
         "consumes": [
           "application/json"
@@ -4449,7 +4449,7 @@
           "Leads"
         ],
         "summary": "Change Lead Program Status",
-        "description": "Changes the program status of a list of leads in a target program. Only existing members of the program may have their status changed with this API. Required Permissions: Read-Write Lead<br><br><b>Note: This endpoint has been superceded.</b>  Use <a href=\"https://developer.adobe.com/marketo-apis/api/mapi/#operation/syncProgramMemberStatusUsingPOST\">Sync Program Member Status</a> endpoint instead.",
+        "description": "Changes the program status of a list of leads in a target program. Only existing members of the program may have their status changed with this API. Required Permissions: Read-Write Lead<br><br><b>Note: This endpoint has been superseded.</b>  Use <a href=\"https://developer.adobe.com/marketo-apis/api/mapi/#operation/syncProgramMemberStatusUsingPOST\">Sync Program Member Status</a> endpoint instead.",
         "operationId": "changeLeadProgramStatusUsingPOST",
         "consumes": [
           "application/json"
@@ -4562,7 +4562,7 @@
           "Leads"
         ],
         "summary": "Associate Lead",
-        "description": "Associates a known Marketo lead record to a munchkin cookie and its associated web acitvity history. Required Permissions: Read-Write Lead",
+        "description": "Associates a known Marketo lead record to a munchkin cookie and its associated web activity history. Required Permissions: Read-Write Lead",
         "operationId": "associateLeadUsingPOST",
         "consumes": [
           "application/json"
@@ -6051,7 +6051,7 @@
           {
             "in": "query",
             "name": "filterValues",
-            "description": "Comma seperated list of search values.",
+            "description": "Comma separated list of search values.",
             "required": true,
             "type": "array",
             "items": {
@@ -11622,7 +11622,7 @@
           }
         },
         "filter": {
-          "description": "Record selection criteria. \"createAt\" is required, \"activityTypeIds\", \"primaryAttributeValueIds\", and \"primaryAttributeValues\" are optional",
+          "description": "Record selection criteria. \"createdAt\" is required, \"activityTypeIds\", \"primaryAttributeValueIds\", and \"primaryAttributeValues\" are optional",
           "$ref": "#/definitions/ExportActivityFilter"
         },
         "format": {
@@ -11645,7 +11645,7 @@
         "total": {
           "type": "integer",
           "format": "int32",
-          "description": "Total number of errors in the time period"
+          "description": "Total number of calls in the time period"
         },
         "users": {
           "type": "array",


### PR DESCRIPTION
## Description

Fixes several typos and misspellings in `swagger-mapi.json`:

| Location | Typo | Fix |
|----------|------|-----|
| Get Campaigns, Get Campaign By Id, Describe Lead, Describe Program Member, Change Lead Program Status | superceded | superseded |
| Associate Lead | acitvity | activity |
| Get SalesPersons filterValues | seperated | separated |
| ExportActivityRequest filter | createAt | createdAt |
| UsageData.total | errors | calls (copy-paste from ErrorsData) |

The `createAt` fix is notable: the description references a field name that does not exist in the `ExportActivityFilter` schema — the actual field is `createdAt`.

The `UsageData.total` description says "Total number of errors" but this is the API usage (calls) schema, not the errors schema. The adjacent `ErrorsData` definition correctly uses this description for its own `total` field.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)