### PR TITLE
Fix CreateEmailRequest.textOnly type from string to boolean

### DIFF
--- a/static/swagger-asset.json
+++ b/static/swagger-asset.json
@@ -10749,7 +10749,7 @@
           "description": "Id of the parent template"
         },
         "textOnly": {
-          "type": "string",
+          "type": "boolean",
           "description": "Setting to include text-only version of email when sent"
         }
       }


### PR DESCRIPTION
## Description

`CreateEmailRequest.textOnly` is typed as `string` but should be `boolean`.

The same field is correctly typed as `boolean` in three other schemas:
- `EmailResponse.textOnly` (line 9423)
- `UpdateEmailMetaDataRequest.textOnly` (line 8808)
- `EmailSendSampleRequest.textOnly` (line 13377)

It is a boolean flag controlling whether to include a text-only version of an email.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)